### PR TITLE
Add new API NPPM_GETSETTINGSONCLOUDPATH for plugins

### DIFF
--- a/PowerEditor/src/MISC/PluginsManager/Notepad_plus_msgs.h
+++ b/PowerEditor/src/MISC/PluginsManager/Notepad_plus_msgs.h
@@ -429,6 +429,26 @@ enum Platform { PF_UNKNOWN, PF_X86, PF_X64, PF_IA64 };
 	// Users should call it with pluginRootPath be NULL to get the required number of TCHAR (not including the terminating nul character),
 	// allocate pluginRootPath buffer with the return value + 1, then call it again to get the path.
 
+	#define NPPM_GETSETTINGSONCLOUDPATH (NPPMSG + 98)
+	// INT NPPM_GETSETTINGSCLOUDPATH(size_t strLen, TCHAR *settingsOnCloudPath)
+	// Get settings on cloud path. It's useful if plugins want to store its settings on Cloud, if this path is set.
+	// Returns the number of TCHAR copied/to copy. If the return value is 0, then this path is not set, or the "strLen" is not enough to copy the path.
+	// Users should call it with settingsCloudPath be NULL to get the required number of TCHAR (not including the terminating nul character),
+	// allocate settingsCloudPath buffer with the return value + 1, then call it again to get the path.
+
+#define VAR_NOT_RECOGNIZED 0
+#define FULL_CURRENT_PATH 1
+#define CURRENT_DIRECTORY 2
+#define FILE_NAME 3
+#define NAME_PART 4
+#define EXT_PART 5
+#define CURRENT_WORD 6
+#define NPP_DIRECTORY 7
+#define CURRENT_LINE 8
+#define CURRENT_COLUMN 9
+#define NPP_FULL_FILE_PATH 10
+#define GETFILENAMEATCURSOR 11
+
 #define	RUNCOMMAND_USER    (WM_USER + 3000)
 	#define NPPM_GETFULLCURRENTPATH		(RUNCOMMAND_USER + FULL_CURRENT_PATH)
 	#define NPPM_GETCURRENTDIRECTORY	(RUNCOMMAND_USER + CURRENT_DIRECTORY)
@@ -453,18 +473,6 @@ enum Platform { PF_UNKNOWN, PF_X86, PF_X64, PF_IA64 };
 
 	#define NPPM_GETNPPFULLFILEPATH			(RUNCOMMAND_USER + NPP_FULL_FILE_PATH)
 
-		#define VAR_NOT_RECOGNIZED 0
-		#define FULL_CURRENT_PATH 1
-		#define CURRENT_DIRECTORY 2
-		#define FILE_NAME 3
-		#define NAME_PART 4
-		#define EXT_PART 5
-		#define CURRENT_WORD 6
-		#define NPP_DIRECTORY 7
-		#define CURRENT_LINE 8
-		#define CURRENT_COLUMN 9
-		#define NPP_FULL_FILE_PATH 10
-		#define GETFILENAMEATCURSOR 11
 
 
 // Notification code

--- a/PowerEditor/src/NppBigSwitch.cpp
+++ b/PowerEditor/src/NppBigSwitch.cpp
@@ -2109,6 +2109,21 @@ LRESULT Notepad_plus::process(HWND hwnd, UINT message, WPARAM wParam, LPARAM lPa
 			return pluginHomePath.length();
 		}
 
+		case NPPM_GETSETTINGSONCLOUDPATH:
+		{
+			const NppGUI & nppGUI = nppParam.getNppGUI();
+			generic_string settingsOnCloudPath = nppGUI._cloudPath;
+			if (lParam != 0)
+			{
+				if (settingsOnCloudPath.length() >= static_cast<size_t>(wParam))
+				{
+					return 0;
+				}
+				lstrcpy(reinterpret_cast<TCHAR *>(lParam), settingsOnCloudPath.c_str());
+			}
+			return settingsOnCloudPath.length();
+		}
+
 		case NPPM_MSGTOPLUGIN :
 		{
 			return _pluginsManager.relayPluginMessages(message, wParam, lParam);


### PR DESCRIPTION
	#define NPPM_GETSETTINGSONCLOUDPATH (NPPMSG + 98)
	// INT NPPM_GETSETTINGSCLOUDPATH(size_t strLen, TCHAR *settingsOnCloudPath)
	// Get settings on cloud path. It's useful if plugins want to store its settings on Cloud, if this path is set.
	// Returns the number of TCHAR copied/to copy. If the return value is 0, then this path is not set, or the "strLen" is not enough to copy the path.
	// Users should call it with settingsCloudPath be NULL to get the required number of TCHAR (not including the terminating nul character),
	// allocate settingsCloudPath buffer with the return value + 1, then call it again to get the path.

Close #9168